### PR TITLE
Allow the WebManifest to be cached

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,7 +8,6 @@ module.exports = {
   },
   plugins: [
     'gatsby-plugin-catch-links',
-    'gatsby-plugin-offline',
     {
       resolve: 'gatsby-plugin-manifest',
       options: {
@@ -21,6 +20,7 @@ module.exports = {
         icon: 'assets/logo.jpg',
       }
     },
+    'gatsby-plugin-offline',
     {
       resolve: 'gatsby-source-filesystem',
       options: {


### PR DESCRIPTION
Hi,

I just followed the Gatsby tutorial and noticed that the `gatsby-plugin-offline` should be placed _after_ the `gatsby-plugin-manifest` to allow for the `manifest.webmanifest` to be cached by the Service Worker.

[Official Doc](https://www.gatsbyjs.org/packages/gatsby-plugin-offline/)
![offline](https://user-images.githubusercontent.com/10831649/62658070-c33b8400-b95f-11e9-902e-f3a7f522823a.png)

So here is a small pull request that does just that 😉

Thanks for your work!

